### PR TITLE
Bug in search form on the Coverage, Available and DID Numbers

### DIFF
--- a/app/javascript/ui/coverage_filter.js
+++ b/app/javascript/ui/coverage_filter.js
@@ -84,18 +84,16 @@ onmount(region_select, () => $(region_select).change(function () {
     }
 }))
 
-$(document).on('ready', function () {
 // On first load, try to fetch region and city lists based on filters
-    onmount(form, function () {
-        if ($(country_select).val()) {
-            if ($(country_select).find(':selected').data('has-regions')) {
-                load_regions()
-                if ($(region_select).data('region-id')) {
-                    load_cities()
-                }
-            } else {
+onmount(form, function () {
+    if ($(country_select).val()) {
+        if ($(country_select).find(':selected').data('has-regions')) {
+            load_regions()
+            if ($(region_select).data('region-id')) {
                 load_cities()
             }
+        } else {
+            load_cities()
         }
-    })
+    }
 })


### PR DESCRIPTION
Description:
After filtering by Country and Region and submitting the search form filters dependent from Country is disappeared from the page.

Expected result:
Filter that belongs to Country should be loaded after reloading the page and should be selected previously selected option.

closes #84 