### PR TITLE
Use last version of V3 API to demonstrate the full power of the API

### DIFF
--- a/config/initializers/didww.rb
+++ b/config/initializers/didww.rb
@@ -7,7 +7,7 @@ require 'didww/countries_with_regions'
 # Initialize client
 DIDWW::Client.configure do |config|
   # config.api_version = '2021-04-19'
-  config.api_version = '2021-12-15'
+  config.api_version = '2022-05-10'
 end
 
 if Rails.env.development? || Rails.env.test?


### PR DESCRIPTION
After patch no matter which API version the customer uses.
Each request will use the last version of the V3 API

fixes #92  

current branch has been deployed to this [place](https://thawing-bastion-45450.herokuapp.com/coverage) 