### PR TITLE
Admin UI: rename "Shared Capacity Group" to "Capacity Group"

### DIFF
--- a/app/controllers/shared_capacity_groups_controller.rb
+++ b/app/controllers/shared_capacity_groups_controller.rb
@@ -7,7 +7,7 @@ class SharedCapacityGroupsController < DashboardController
 
   def create
     if resource.save
-      flash[:success] = 'Shared Capacity Group was successfully created.'
+      flash[:success] = 'Capacity Group was successfully created.'
       redirect_to shared_capacity_group_path(resource)
     else
       render :new
@@ -16,7 +16,7 @@ class SharedCapacityGroupsController < DashboardController
 
   def update
     if resource.save
-      flash[:success] = 'Shared Capacity Group was successfully updated.'
+      flash[:success] = 'Capacity Group was successfully updated.'
       redirect_to shared_capacity_group_path(resource)
     else
       render :edit
@@ -25,10 +25,10 @@ class SharedCapacityGroupsController < DashboardController
 
   def destroy
     if resource.destroy
-      flash[:success] = 'Shared Capacity Group was successfully deleted.'
+      flash[:success] = 'Capacity Group was successfully deleted.'
       redirect_to shared_capacity_groups_path
     else
-      flash[:danger] = 'Failed to delete Shared Capacity Group: ' + resource.errors[:base].join('. ')
+      flash[:danger] = 'Failed to delete Capacity Group: ' + resource.errors[:base].join('. ')
       redirect_back fallback_location: shared_capacity_group_path(resource)
     end
   end
@@ -92,7 +92,7 @@ class SharedCapacityGroupsController < DashboardController
   end
 
   def selectable_dids
-    # DIDs that match countries with current shared capacity group's capacity pool
+    # DIDs that match countries with current capacity group's capacity pool
     @selectable_dids ||= begin
       dids = DIDWW::Resource::Did.includes(:'did_group.country').all
       if resource.capacity_pool

--- a/app/views/capacity_pools/show.html.erb
+++ b/app/views/capacity_pools/show.html.erb
@@ -72,7 +72,7 @@
 
     <% if resource.shared_capacity_groups.any? %>
       <p>
-        Shared capacity groups:
+        Capacity Groups:
       </p>
 
       <table class="table table-striped table-bordered table-condensed table-hover clickable">
@@ -95,7 +95,7 @@
               <td class="text-right text-nowrap">
                 <%= show_button shared_capacity_group_path(shared_capacity_group), :small %>
                 <%= edit_button edit_shared_capacity_group_path(shared_capacity_group), :small %>
-                <%= delete_button shared_capacity_group_path(shared_capacity_group), :small, confirm: 'Are you sure to delete this Shared Capacity Group?' %>
+                <%= delete_button shared_capacity_group_path(shared_capacity_group), :small, confirm: 'Are you sure to delete this Capacity Group?' %>
               </td>
             </tr>
           <% end %>
@@ -106,7 +106,7 @@
     <div class="row">
       <div class="col-lg-12">
         <%= link_to new_shared_capacity_group_path(capacity_pool_id: resource.id), class: "btn btn-success" do %>
-          <i class="fa fa-plus fa-lg"></i>&nbsp;&nbsp;Add Shared Capacity Group&nbsp;&nbsp;
+          <i class="fa fa-plus fa-lg"></i>&nbsp;&nbsp;Add Capacity Group&nbsp;&nbsp;
         <% end %>
       </div>
     </div>

--- a/app/views/layouts/dashboard/_navbar-side.html.erb
+++ b/app/views/layouts/dashboard/_navbar-side.html.erb
@@ -26,7 +26,7 @@
             </li>
             <li>
               <%= link_to shared_capacity_groups_path do %>
-                <i class="fa fa-server fa-fw"></i> Shared Capacity Groups
+                <i class="fa fa-server fa-fw"></i> Capacity Groups
               <% end %>
             </li>
             <li>

--- a/app/views/shared_capacity_groups/_form.html.erb
+++ b/app/views/shared_capacity_groups/_form.html.erb
@@ -40,7 +40,8 @@
     <div class="col-md-12">
       <hr />
       <div class="form-group">
-        <%= f.submit class: "btn btn-success", data: { disable_with: "Submitting" } %>
+        <% verb = f.object.new_record? ? 'Create' : 'Update' %>
+        <%= f.submit "#{verb} Capacity Group", class: "btn btn-success", data: { disable_with: "Submitting" } %>
       </div>
     </div>
   </div>

--- a/app/views/shared_capacity_groups/_shared_capacity_group.html.erb
+++ b/app/views/shared_capacity_groups/_shared_capacity_group.html.erb
@@ -12,7 +12,7 @@
   <td class="text-right text-nowrap">
     <%= show_button shared_capacity_group_path(shared_capacity_group), :small %>
     <%= edit_button edit_shared_capacity_group_path(shared_capacity_group), :small %>
-    <%= delete_button shared_capacity_group_path(shared_capacity_group), :small, confirm: 'Are you sure to delete this Shared Capacity Group?' %>
+    <%= delete_button shared_capacity_group_path(shared_capacity_group), :small, confirm: 'Are you sure to delete this Capacity Group?' %>
   </td>
 </tr>
 

--- a/app/views/shared_capacity_groups/edit.html.erb
+++ b/app/views/shared_capacity_groups/edit.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <%= link_to 'My Shared Capacity Groups', shared_capacity_groups_path %> >
+    <%= link_to 'My Capacity Groups', shared_capacity_groups_path %> >
     <%= link_to resource.attribute_was(:name), shared_capacity_group_path(resource) %> >
     Edit
   </div>

--- a/app/views/shared_capacity_groups/index.html.erb
+++ b/app/views/shared_capacity_groups/index.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    My Shared Capacity Groups
+    My Capacity Groups
   </div>
   <!-- /.panel-heading -->
   <div class="panel-body">

--- a/app/views/shared_capacity_groups/new.html.erb
+++ b/app/views/shared_capacity_groups/new.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <%= link_to 'My Shared Capacity Groups', shared_capacity_groups_path %> >
-    Create Shared Capacity Group
+    <%= link_to 'My Capacity Groups', shared_capacity_groups_path %> >
+    Create Capacity Group
   </div>
   <!-- /.panel-heading -->
   <div class="panel-body">

--- a/app/views/shared_capacity_groups/show.html.erb
+++ b/app/views/shared_capacity_groups/show.html.erb
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <%= link_to 'My Shared Capacity Groups', shared_capacity_groups_path %> >
+    <%= link_to 'My Capacity Groups', shared_capacity_groups_path %> >
     <%= resource.name %>
   </div>
   <!-- /.panel-heading -->
@@ -26,7 +26,7 @@
     <div class="row">
       <div class="col-lg-12">
         <%= edit_button edit_shared_capacity_group_path(resource) %>
-        <%= delete_button shared_capacity_group_path(resource), confirm: 'Are you sure to delete this Shared Capacity Group?' %>
+        <%= delete_button shared_capacity_group_path(resource), confirm: 'Are you sure to delete this Capacity Group?' %>
       </div>
     </div>
 


### PR DESCRIPTION
### Rename "Shared Capacity Group"

The name "Shared Capacity Group" has already been deprecated.


There is no entity on the [User Panel](my.didww.com) with a "Shared Capacity Group" name, therefore it is necessary to synchronize these name with User Panel

## Screenshots:
<img width="252" alt="Screenshot 2023-02-28 at 02 56 08" src="https://user-images.githubusercontent.com/10907664/221724340-00ea97ce-e83a-4982-9763-e355f99383ea.png">

<img width="1503" alt="Screenshot 2023-02-28 at 02 57 55" src="https://user-images.githubusercontent.com/10907664/221724475-dff429c9-b38b-4f93-a7e8-1480807d0392.png">


<img width="1492" alt="Screenshot 2023-02-28 at 03 23 14" src="https://user-images.githubusercontent.com/10907664/221728240-991258a1-ff54-43f5-bf26-b659a2474b63.png">

Remove the flesh message when removing "Capacity Group"
<img width="332" alt="Screenshot 2023-02-28 at 03 26 38" src="https://user-images.githubusercontent.com/10907664/221728750-69fc8e5e-5c36-4e12-81ea-54b0b6b72909.png">
