### PR TITLE
Use Ruby version from .ruby-version file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Ruby
       - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
       - name: Run tests
         run: |
           gem install bundler -v 2.2.7


### PR DESCRIPTION
So we have one place `.ruby-version` when you can configure ruby version