### PR TITLE
bugfix: #118, rename voice & sms features of DID Group

### DIFF
--- a/app/views/available_dids/_row.html.erb
+++ b/app/views/available_dids/_row.html.erb
@@ -11,9 +11,9 @@
   <td><%= available_did.did_group.area_name %></td>
   <td><%= available_did.did_group.did_group_type.name %></td>
   <td class="text-center text-nowrap">
-    <%= available_did.did_group.features.include?('voice') ? '✓' : '✗' %> &nbsp;
+    <%= available_did.did_group.features.include?('voice_in') ? '✓' : '✗' %> &nbsp;
     <%= available_did.did_group.features.include?('t38') ? '✓' : '✗' %> &nbsp;
-    <%= available_did.did_group.features.include?('sms') ? '✓' : '✗' %>
+    <%= available_did.did_group.features.include?('sms_in') ? '✓' : '✗' %>
   </td>
   <td><%= available_did.did_group.is_metered ? '✓' : '✗' %></td>
   <td><%= available_did.did_group.allow_additional_channels ? 'Yes' : 'No' %></td>

--- a/app/views/available_dids/_table.html.erb
+++ b/app/views/available_dids/_table.html.erb
@@ -9,7 +9,7 @@
       <th>Country</th>
       <th>Area name</th>
       <th>Type</th>
-      <th class="text-center">Voice | T.38 | SMS</th>
+      <th class="text-center">Voice IN | T.38 | SMS IN</th>
       <th>Metered</th>
       <th>Add. channels</th>
       <th>Channels included</th>

--- a/app/views/coverage/_did_group.html.erb
+++ b/app/views/coverage/_did_group.html.erb
@@ -12,9 +12,9 @@
   </td>
   <td class="text-center"><%= did_group.meta[:is_available] ? '✓' : '✗' %></td>
   <td class="text-center text-nowrap">
-    <%= did_group.features.include?('voice') ? '✓' : '✗' %> &nbsp;
+    <%= did_group.features.include?('voice_in') ? '✓' : '✗' %> &nbsp;
     <%= did_group.features.include?('t38') ? '✓' : '✗' %> &nbsp;
-    <%= did_group.features.include?('sms') ? '✓' : '✗' %>
+    <%= did_group.features.include?('sms_in') ? '✓' : '✗' %>
   </td>
   <td><%= did_group.is_metered ? '✓' : '✗' %></td>
   <td><%= did_group.allow_additional_channels ? 'Yes' : 'No' %></td>

--- a/app/views/coverage/_filter.html.erb
+++ b/app/views/coverage/_filter.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-6 js-dynamic-cities js-only-available">
       <div class="form-group">
         <label>Required features:</label><br>
-        <% resource_klass::FEATURES.each do |val, human| %>
+        <% { 'voice_in' => 'Voice IN', 't38' => 'T.38 Fax', 'sms_in' => 'SMS IN' }.each do |val, human| %>
           <label class="checkbox-inline">
             <%= check_box_tag 'q[features][]', val, filters['features']&.include?(val) %>
             <%= human %>

--- a/app/views/coverage/index.html.erb
+++ b/app/views/coverage/index.html.erb
@@ -36,7 +36,7 @@
                   <th><%= sort_link :'did_group_type.name', 'Type' %></th>
                   <th>Registration</th>
                   <th class="text-center">Available</th>
-                  <th class="text-center">Voice | T.38 | SMS</th>
+                  <th class="text-center">Voice IN | T.38 | SMS IN</th>
                   <th><%= sort_link :is_metered, 'Metered' %></th>
                   <th><%= sort_link :allow_additional_channels, 'Add. channels' %></th>
                   <th>Channels included</th>

--- a/app/views/did_reservations/_row.html.erb
+++ b/app/views/did_reservations/_row.html.erb
@@ -30,9 +30,9 @@
   <td><%= did_reservation.available_did.did_group.area_name %></td>
   <td><%= did_reservation.available_did.did_group.did_group_type.name %></td>
   <td class="text-center text-nowrap">
-    <%= did_reservation.available_did.did_group.features.include?('voice') ? '✓' : '✗' %> &nbsp;
+    <%= did_reservation.available_did.did_group.features.include?('voice_in') ? '✓' : '✗' %> &nbsp;
     <%= did_reservation.available_did.did_group.features.include?('t38') ? '✓' : '✗' %> &nbsp;
-    <%= did_reservation.available_did.did_group.features.include?('sms') ? '✓' : '✗' %>
+    <%= did_reservation.available_did.did_group.features.include?('sms_in') ? '✓' : '✗' %>
   </td>
   <td><%= did_reservation.available_did.did_group.is_metered ? '✓' : '✗' %></td>
   <td><%= did_reservation.available_did.did_group.allow_additional_channels ? 'Yes' : 'No' %></td>

--- a/app/views/did_reservations/_table.html.erb
+++ b/app/views/did_reservations/_table.html.erb
@@ -10,7 +10,7 @@
       <th>Country</th>
       <th>Area name</th>
       <th>Type</th>
-      <th class="text-center">Voice | T.38 | SMS</th>
+      <th class="text-center">Voice IN | T.38 | SMS IN</th>
       <th>Metered</th>
       <th>Add. channels</th>
       <th>Channels included</th>

--- a/app/views/did_reservations/show.html.erb
+++ b/app/views/did_reservations/show.html.erb
@@ -48,9 +48,9 @@
           <tr>
             <td class="<%= attribute_row_classes %>"><strong>Features</strong></td>
             <td class="text-center text-nowrap">
-              <%= did_group.features.include?('voice') ? '✓' : '✗' %> &nbsp;
+              <%= did_group.features.include?('voice_in') ? '✓' : '✗' %> &nbsp;
               <%= did_group.features.include?('t38') ? '✓' : '✗' %> &nbsp;
-              <%= did_group.features.include?('sms') ? '✓' : '✗' %>
+              <%= did_group.features.include?('sms_in') ? '✓' : '✗' %>
             </td>
           </tr>
           <%= attribute_row :metered,

--- a/app/views/orders/_did_order_item_form_fields.html.erb
+++ b/app/views/orders/_did_order_item_form_fields.html.erb
@@ -6,7 +6,7 @@
           <tr>
             <th>DID</th>
             <th>Type</th>
-            <th class="text-center">Voice | T.38 | SMS</th>
+            <th class="text-center">Voice IN | T.38 | SMS IN</th>
             <th>Channels included</th>
             <th>Setup price (NRC)</th>
             <th>Monthly price (MRC)</th>
@@ -25,9 +25,9 @@
               </td>
               <td><%= did_group.did_group_type.name %></td>
               <td class="text-center text-nowrap">
-                <%= did_group.features.include?('voice') ? '✓' : '✗' %> &nbsp;
+                <%= did_group.features.include?('voice_in') ? '✓' : '✗' %> &nbsp;
                 <%= did_group.features.include?('t38') ? '✓' : '✗' %> &nbsp;
-                <%= did_group.features.include?('sms') ? '✓' : '✗' %>
+                <%= did_group.features.include?('sms_in') ? '✓' : '✗' %>
               </td>
               <td>
                 <%= conf.hidden_field :did_group_id %>


### PR DESCRIPTION
bugfix: #118, rename voice & sms features of DID Group to new name voice_in & sms_in

according to the documentation of the latest V3 API https://doc.didww.com/api3/2022-05-10/coverage-resources/did-group/get-did-groups.html

closes #118